### PR TITLE
Refactor sending

### DIFF
--- a/app/src/main/java/com/rsoultanaev/sphinxproxy/AsyncTcpClient.java
+++ b/app/src/main/java/com/rsoultanaev/sphinxproxy/AsyncTcpClient.java
@@ -8,7 +8,7 @@ import com.koushikdutta.async.callback.ConnectCallback;
 
 import java.net.InetSocketAddress;
 
-class AsyncTcpClient {
+public class AsyncTcpClient {
 
     private String host;
     private int port;

--- a/app/src/main/java/com/rsoultanaev/sphinxproxy/Constants.java
+++ b/app/src/main/java/com/rsoultanaev/sphinxproxy/Constants.java
@@ -1,6 +1,0 @@
-package com.rsoultanaev.sphinxproxy;
-
-public class Constants {
-    public static int PACKET_HEADER_SIZE = 24;
-    public static int PACKET_PAYLOAD_SIZE = 300;
-}

--- a/app/src/main/java/com/rsoultanaev/sphinxproxy/Pop3Puller.java
+++ b/app/src/main/java/com/rsoultanaev/sphinxproxy/Pop3Puller.java
@@ -123,7 +123,7 @@ public class Pop3Puller {
         byte[] encodedMessage = getMessageBody(reader);
         byte[] message = Base64.decode(encodedMessage);
 
-        byte[] headerBytes = Arrays.copyOfRange(message, 0, Constants.PACKET_HEADER_SIZE);
+        byte[] headerBytes = Arrays.copyOfRange(message, 0, SphinxUtil.PACKET_HEADER_SIZE);
         ByteBuffer byteBuffer = ByteBuffer.wrap(headerBytes);
         long uuidHigh = byteBuffer.getLong();
         long uuidLow = byteBuffer.getLong();

--- a/app/src/main/java/com/rsoultanaev/sphinxproxy/SphinxUtil.java
+++ b/app/src/main/java/com/rsoultanaev/sphinxproxy/SphinxUtil.java
@@ -49,7 +49,7 @@ public class SphinxUtil {
         publicKeys.put(8002, decodeECPoint(Hex.decode("02739a6205b940db5dd4c62c17fe568dc1b061a150322df9a45543898f")));
     }
 
-    public void sendMailWithSphinx(byte[] email, String recipient) {
+    public byte[][] splitIntoSphinxPackets(byte[] email, String recipient) {
         byte[] dest = recipient.getBytes();
 
         UUID messageId = UUID.randomUUID();
@@ -72,11 +72,7 @@ public class SphinxUtil {
             sphinxPackets[i] = createBinSphinxPacket(dest, encodedSphinxPayload, routingInformation);
         }
 
-        AsyncTcpClient asyncTcpClient = new AsyncTcpClient("localhost", 10000);
-
-        for (byte[] binMessage : sphinxPackets) {
-            asyncTcpClient.sendMessage(binMessage);
-        }
+        return sphinxPackets;
     }
 
     private byte[] createBinSphinxPacket(byte[] dest, byte[] message, RoutingInformation routingInformation) {

--- a/app/src/main/java/com/rsoultanaev/sphinxproxy/SphinxUtil.java
+++ b/app/src/main/java/com/rsoultanaev/sphinxproxy/SphinxUtil.java
@@ -26,6 +26,9 @@ import java.util.UUID;
 
 public class SphinxUtil {
 
+    public static int PACKET_HEADER_SIZE = 24;
+    public static int PACKET_PAYLOAD_SIZE = 300;
+
     private class RoutingInformation {
         byte[][] nodesRouting;
         ECPoint[] nodeKeys;
@@ -53,18 +56,18 @@ public class SphinxUtil {
         byte[] dest = recipient.getBytes();
 
         UUID messageId = UUID.randomUUID();
-        int packetsInMessage = (int) Math.ceil((double) email.length / Constants.PACKET_PAYLOAD_SIZE);
+        int packetsInMessage = (int) Math.ceil((double) email.length / SphinxUtil.PACKET_PAYLOAD_SIZE);
 
         byte[][] sphinxPackets = new byte[packetsInMessage][];
         for (int i = 0; i < packetsInMessage; i++) {
 
-            ByteBuffer packetHeader = ByteBuffer.allocate(Constants.PACKET_HEADER_SIZE);
+            ByteBuffer packetHeader = ByteBuffer.allocate(SphinxUtil.PACKET_HEADER_SIZE);
             packetHeader.putLong(messageId.getMostSignificantBits());
             packetHeader.putLong(messageId.getLeastSignificantBits());
             packetHeader.putInt(packetsInMessage);
             packetHeader.putInt(i);
 
-            byte[] packetPayload = copyUpToNum(email, Constants.PACKET_PAYLOAD_SIZE * i, Constants.PACKET_PAYLOAD_SIZE);
+            byte[] packetPayload = copyUpToNum(email, SphinxUtil.PACKET_PAYLOAD_SIZE * i, SphinxUtil.PACKET_PAYLOAD_SIZE);
             byte[] encodedSphinxPayload = Base64.encode(concatByteArrays(packetHeader.array(), packetPayload));
 
             RoutingInformation routingInformation = generateRoutingInformation();

--- a/app/src/main/java/com/rsoultanaev/sphinxproxy/server/SmtpMessageHandler.java
+++ b/app/src/main/java/com/rsoultanaev/sphinxproxy/server/SmtpMessageHandler.java
@@ -1,5 +1,6 @@
 package com.rsoultanaev.sphinxproxy.server;
 
+import com.rsoultanaev.sphinxproxy.AsyncTcpClient;
 import com.rsoultanaev.sphinxproxy.SphinxUtil;
 
 import org.subethamail.smtp.helper.SimpleMessageListener;
@@ -36,6 +37,12 @@ public class SmtpMessageHandler implements SimpleMessageListener {
         System.out.println("-------------------------");
 
         SphinxUtil sphinxUtil = new SphinxUtil();
-        sphinxUtil.sendMailWithSphinx(email, recipient);
+        byte[][] sphinxPackets = sphinxUtil.splitIntoSphinxPackets(email, recipient);
+
+        AsyncTcpClient asyncTcpClient = new AsyncTcpClient("localhost", 10000);
+
+        for (byte[] binMessage : sphinxPackets) {
+            asyncTcpClient.sendMessage(binMessage);
+        }
     }
 }


### PR DESCRIPTION
Some refactoring to the sending code.

Calculate the size of packet payloads correctly, so that after we base64-encode the header concatenated with the packet payload, the result is as close as possible to the Sphinx limit but never over it.